### PR TITLE
Add additional edges in Dijkstra initialization round

### DIFF
--- a/FlexLabel/src/FlexLabel.cxx
+++ b/FlexLabel/src/FlexLabel.cxx
@@ -217,6 +217,8 @@ std::vector<Grid3DExt::edge_t> Grid3DExt::neighbourEdges(const float maxR) const
 		}
 	}
 	idxs.shrink_to_fit();
+	// change sort to stable_sort to preserve order of equivalent distances (for debugging)
+	// std::stable_sort(idxs.begin(), idxs.end(),
 	std::sort(idxs.begin(), idxs.end(),
 		  [](const edge_t &lhs, const edge_t &rhs) {
 			  return lhs.r < rhs.r;


### PR DESCRIPTION
Hi Thomas and Mykola,
I would like to propose a small change to the grid search of *LabelLib* to avoid empty AVs due to the linker getting blocked close to the attachment point on the biomolecule.
In the initialization round of the Dijkstra algorithm, I suggest to search all grid within a radius `linkerDiameterPlusgridSize` (i.e linker width + grid spacing) instead of just `essentialNeighbours` (as in all subsequent rounds).
This prevents the algorithm from terminating prematurely when no grid points are within the 74 essential neighbors edges (i.e. for residues which are slightly less surface-accessible). 
Since the extended neighbor list only affects the very first round of the Dijkstra algorithm, the time cost is negligible.
I believe a somewhat similar adjustment for the initialization round was originally proposed in Kalinin, *Nat. Methods.* (2012).
Let me know what you think.
Kind regards,
Fabio